### PR TITLE
fix max active connections

### DIFF
--- a/livelessons-cloud/livelessons-cloud-services/src/main/resources/application.properties
+++ b/livelessons-cloud/livelessons-cloud-services/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 spring.datasource.continue-on-error=true
 spring.datasource.url=${cloud.services.ll-car-sql-database.connection.jdbcurl}
-spring.datasource.max-active=1
+spring.datasource.tomcat.max-active=1


### PR DESCRIPTION
Dear all,
application.properties of the module livelessons-cloud-services contains
spring.datasource.max-active=1
but it should be
spring.datasource.tomcat.max-active=1